### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,5 +1,8 @@
 name: .NET Build and Test Coverage
 
+permissions:
+    contents: read
+
 on:
     push:
         branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/Janobob/StreamHub/security/code-scanning/6](https://github.com/Janobob/StreamHub/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow only needs to read the repository contents to build and test the solution. No write permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
