### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/angular-build.yml
+++ b/.github/workflows/angular-build.yml
@@ -7,6 +7,9 @@ on:
     pull_request:
         types: [opened, synchronize, reopened]
 
+permissions:
+    contents: read
+
 jobs:
     build:
         name: Build Angular App


### PR DESCRIPTION
Potential fix for [https://github.com/Janobob/StreamHub/security/code-scanning/5](https://github.com/Janobob/StreamHub/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out the repository, installing dependencies, running tests, and building the application), we will set `contents: read` as the minimal required permission. This ensures that the workflow has only the necessary privileges and no unintended write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
